### PR TITLE
URL Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ For example:
 
   # A URL pointing to the repository where users can
   # find the code.
-  "repository": "http://github.com/Shumkov/Rediska",
+  "repository": "https://github.com/Shumkov/Rediska",
 
   # A short, free-text description of the client.
   # Should be objective. The goal is to help users

--- a/clients.json
+++ b/clients.json
@@ -2,7 +2,7 @@
   {
     "name": "redis-rb",
     "language": "Ruby",
-    "url": "http://redis-rb.keyvalue.org",
+    "url": "https://redis-rb.keyvalue.org",
     "repository": "https://github.com/redis/redis-rb",
     "description": "Very stable and mature client. Install and require the hiredis gem before redis-rb for maximum performances.",
     "authors": ["ezmobius", "soveran", "djanowski", "pnoordhuis"],
@@ -39,7 +39,7 @@
   {
     "name": "CL-Redis",
     "language": "Common Lisp",
-    "url": "http://www.cliki.net/cl-redis",
+    "url": "https://www.cliki.net/cl-redis",
     "repository": "https://github.com/vseloved/cl-redis",
     "description": "",
     "authors": ["BigThingist"],
@@ -114,7 +114,7 @@
   {
     "name": "Tideland CGL Redis",
     "language": "Go",
-    "repository": "http://code.google.com/p/tcgl/",
+    "repository": "https://code.google.com/p/tcgl/",
     "description": "A flexible Go Redis client able to handle all commands",
     "authors": ["themue"],
     "active": true
@@ -132,7 +132,7 @@
   {
     "name": "hedis",
     "language": "Haskell",
-    "url": "http://hackage.haskell.org/package/hedis",
+    "url": "https://hackage.haskell.org/package/hedis",
     "repository": "https://github.com/informatikr/hedis",
     "description": "Supports the complete command set. Commands are automatically pipelined for high performance.",
     "authors": [],
@@ -143,8 +143,8 @@
   {
     "name": "haskell-redis",
     "language": "Haskell",
-    "url": "http://bitbucket.org/videlalvaro/redis-haskell/wiki/Home",
-    "repository": "http://bitbucket.org/videlalvaro/redis-haskell/src",
+    "url": "https://bitbucket.org/videlalvaro/redis-haskell/wiki/Home",
+    "repository": "https://bitbucket.org/videlalvaro/redis-haskell/src",
     "description": "Not actively maintained, supports Redis <= 2.0.",
     "authors": ["old_sound"]
   },
@@ -162,7 +162,7 @@
   {
     "name": "JRedis",
     "language": "Java",
-    "url": "http://code.google.com/p/jredis",
+    "url": "https://code.google.com/p/jredis",
     "repository": "https://github.com/alphazero/jredis",
     "description": "",
     "authors": ["SunOf27"],
@@ -172,8 +172,8 @@
   {
     "name": "JDBC-Redis",
     "language": "Java",
-    "url": "http://code.google.com/p/jdbc-redis",
-    "repository": "http://code.google.com/p/jdbc-redis/source/browse",
+    "url": "https://code.google.com/p/jdbc-redis",
+    "repository": "https://code.google.com/p/jdbc-redis/source/browse",
     "description": "",
     "authors": ["mavcunha"]
   },
@@ -217,7 +217,7 @@
   {
     "name": "Redis",
     "language": "Perl",
-    "url": "http://search.cpan.org/dist/Redis",
+    "url": "https://search.cpan.org/dist/Redis",
     "repository": "https://github.com/melo/perl-redis",
     "description": "Perl binding for Redis database",
     "authors": ["pedromelo"],
@@ -228,7 +228,7 @@
   {
     "name": "RedisDB",
     "language": "Perl",
-    "url": "http://search.cpan.org/dist/RedisDB",
+    "url": "https://search.cpan.org/dist/RedisDB",
     "repository": "https://github.com/trinitum/RedisDB",
     "description": "Perl binding for Redis database with fast XS-based protocolparser",
     "authors": ["trinitum"],
@@ -238,7 +238,7 @@
   {
     "name": "Redis::hiredis",
     "language": "Perl",
-    "url": "http://search.cpan.org/dist/Redis-hiredis/",
+    "url": "https://search.cpan.org/dist/Redis-hiredis/",
     "description": "Perl binding for the hiredis C client",
     "authors": ["neophenix"],
     "active": true
@@ -247,7 +247,7 @@
   {
     "name": "AnyEvent::Redis",
     "language": "Perl",
-    "url": "http://search.cpan.org/dist/AnyEvent-Redis",
+    "url": "https://search.cpan.org/dist/AnyEvent-Redis",
     "repository": "https://github.com/miyagawa/AnyEvent-Redis",
     "description": "Non-blocking Redis client",
     "authors": ["miyagawa"]
@@ -256,7 +256,7 @@
   {
     "name": "AnyEvent::Redis::RipeRedis",
     "language": "Perl",
-    "url": "http://search.cpan.org/dist/AnyEvent-Redis-RipeRedis",
+    "url": "https://search.cpan.org/dist/AnyEvent-Redis-RipeRedis",
     "repository": "https://github.com/iph0/AnyEvent-Redis-RipeRedis",
     "description": "Flexible non-blocking Redis client with reconnect feature",
     "authors": ["iph"],
@@ -266,7 +266,7 @@
   {
     "name": "AnyEvent::Hiredis",
     "language": "Perl",
-    "url": "http://search.cpan.org/dist/AnyEvent-Hiredis",
+    "url": "https://search.cpan.org/dist/AnyEvent-Hiredis",
     "repository": "https://github.com/wjackson/AnyEvent-Hiredis",
     "description": "Non-blocking client using the hiredis C library",
     "authors": [],
@@ -276,7 +276,7 @@
   {
     "name": "MojoX::Redis",
     "language": "Perl",
-    "url": "http://search.cpan.org/dist/MojoX-Redis",
+    "url": "https://search.cpan.org/dist/MojoX-Redis",
     "repository": "https://github.com/und3f/mojox-redis",
     "description": "asynchronous Redis client for Mojolicious",
     "authors": ["und3f"],
@@ -286,7 +286,7 @@
   {
     "name": "Danga::Socket::Redis",
     "language": "Perl",
-    "url": "http://search.cpan.org/dist/Danga-Socket-Redis",
+    "url": "https://search.cpan.org/dist/Danga-Socket-Redis",
     "description": "An asynchronous redis client using the Danga::Socket async library",
     "authors": ["martinredmond"]
   },
@@ -359,7 +359,7 @@
   {
     "name": "txredis",
     "language": "Python",
-    "url": "http://pypi.python.org/pypi/txredis/0.1.1",
+    "url": "https://pypi.python.org/pypi/txredis/0.1.1",
     "description": "",
     "authors": ["dio_rian"]
   },
@@ -410,7 +410,7 @@
     "name": "scala-redis-client",
     "language": "Scala",
     "repository": "https://github.com/top10/scala-redis-client",
-    "description": "An idiomatic Scala client that keeps Jedis / Java hidden. Used in production at http://top10.com.",
+    "description": "An idiomatic Scala client that keeps Jedis / Java hidden. Used in production at https://top10.com.",
     "authors": ["thesmith", "heychinaski"],
     "active": true
   },
@@ -436,7 +436,7 @@
   {
     "name": "Booksleeve",
     "language": "C#",
-    "url": "http://code.google.com/p/booksleeve/",
+    "url": "https://code.google.com/p/booksleeve/",
     "description": "This client was developed by Stack Exchange for very high performance needs.",
     "authors": ["marcgravell"],
     "recommended": true,
@@ -446,7 +446,7 @@
   {
     "name": "Sider",
     "language": "C#",
-    "url": "http://nuget.org/List/Packages/Sider",
+    "url": "https://nuget.org/List/Packages/Sider",
     "description": "Minimalistic client for C#/.NET 4.0",
     "authors": ["chakrit"]
   },
@@ -464,8 +464,8 @@
   {
     "name": "hxneko-redis",
     "language": "haXe",
-    "url": "http://code.google.com/p/hxneko-redis",
-    "repository": "http://code.google.com/p/hxneko-redis/source/browse",
+    "url": "https://code.google.com/p/hxneko-redis",
+    "repository": "https://code.google.com/p/hxneko-redis/source/browse",
     "description": "",
     "authors": []
   },
@@ -491,7 +491,7 @@
   {
     "name": "credis",
     "language": "C",
-    "repository": "http://code.google.com/p/credis/source/browse",
+    "repository": "https://code.google.com/p/credis/source/browse",
     "description": "",
     "authors": [""],
     "active": true
@@ -534,7 +534,7 @@
   {
     "name": "Smalltalk Redis Client",
     "language": "Smalltalk",
-    "repository": "http://www.squeaksource.com/Redis.html",
+    "repository": "/@cpavrZLip1SN2gzC/NeRH3bgR",
     "description": "",
     "authors": []
   },
@@ -542,7 +542,7 @@
   {
     "name": "TeamDev Redis Client",
     "language": "C#",
-    "repository": "http://redis.codeplex.com/",
+    "repository": "https://redis.codeplex.com/",
     "description": "Redis Client is based on redis-sharp for the basic communication functions, but it offers some differences.",
     "authors": ["TeamDevPerugia"]
   },
@@ -589,7 +589,7 @@
   {
     "name": "eredis",
     "language": "emacs lisp",
-    "repository": "http://code.google.com/p/eredis",
+    "repository": "https://code.google.com/p/eredis",
     "description": "Full Redis API plus ways to pull Redis data into an org-mode table and push it back when edited",
     "authors": ["justinhj"]
   },
@@ -597,7 +597,7 @@
   {
     "name": "Tiny Redis",
     "language": "D",
-    "url": "http://adilbaig.github.com/Tiny-Redis/",
+    "url": "https://adilbaig.github.com/Tiny-Redis/",
     "repository": "https://github.com/adilbaig/Tiny-Redis",
     "description": "",
     "authors": ["adilbaig"]
@@ -606,7 +606,7 @@
   {
     "name": "redis-client",
     "language": "Scheme",
-    "url": "http://wiki.call-cc.org/eggref/4/redis-client",
+    "url": "https://wiki.call-cc.org/eggref/4/redis-client",
     "repository": "https://github.com/carld/redis-client.egg",
     "description": "A Redis client for Chicken Scheme 4.7",
     "authors": ["carld"]

--- a/commands/bitcount.md
+++ b/commands/bitcount.md
@@ -49,7 +49,7 @@ A similar pattern where user IDs are used instead of days is described
 in the article called "[Fast easy realtime metrics using Redis
 bitmaps][hbgc212fermurb]".
 
-[hbgc212fermurb]: http://blog.getspool.com/2011/11/29/fast-easy-realtime-metrics-using-redis-bitmaps
+[hbgc212fermurb]: https://blog.getspool.com/2011/11/29/fast-easy-realtime-metrics-using-redis-bitmaps
 
 ## Performance considerations
 

--- a/commands/bitop.md
+++ b/commands/bitop.md
@@ -49,7 +49,7 @@ the population counting operation is performed.
 See the article called "[Fast easy realtime metrics using Redis
 bitmaps][hbgc212fermurb]" for a interesting use cases.
 
-[hbgc212fermurb]: http://blog.getspool.com/2011/11/29/fast-easy-realtime-metrics-using-redis-bitmaps
+[hbgc212fermurb]: https://blog.getspool.com/2011/11/29/fast-easy-realtime-metrics-using-redis-bitmaps
 
 ## Performance considerations
 

--- a/commands/config get.md
+++ b/commands/config get.md
@@ -28,7 +28,7 @@ All the supported parameters have the same meaning of the equivalent
 configuration parameter used in the [redis.conf][hgcarr22rc] file, with the
 following important differences:
 
-[hgcarr22rc]: http://github.com/antirez/redis/raw/2.2/redis.conf
+[hgcarr22rc]: https://github.com/antirez/redis/raw/2.2/redis.conf
 
 * Where bytes or other quantities are specified, it is not possible to use
   the `redis.conf` abbreviated form (10k 2gb ... and so forth), everything

--- a/commands/config set.md
+++ b/commands/config set.md
@@ -14,7 +14,7 @@ All the supported parameters have the same meaning of the equivalent
 configuration parameter used in the [redis.conf][hgcarr22rc] file, with the
 following important differences:
 
-[hgcarr22rc]: http://github.com/antirez/redis/raw/2.2/redis.conf
+[hgcarr22rc]: https://github.com/antirez/redis/raw/2.2/redis.conf
 
 * Where bytes or other quantities are specified, it is not possible to use
   the `redis.conf` abbreviated form (10k 2gb ... and so forth), everything

--- a/commands/eval.md
+++ b/commands/eval.md
@@ -116,7 +116,7 @@ Redis to Lua conversion rule:
 Also there are two important rules to note:
 
 * Lua has a single numerical type, Lua numbers. There is no distinction between integers and floats. So we always convert Lua numbers into integer replies, removing the decimal part of the number if any. **If you want to return a float from Lua you should return it as a string**, exactly like Redis itself does (see for instance the `ZSCORE` command).
-* There is [no simple way to have nils inside Lua arrays](http://www.lua.org/pil/19.1.html), this is a result of Lua table semantics, so when Redis converts a Lua array into Redis protocol the conversion is stopped if a nil is encountered.
+* There is [no simple way to have nils inside Lua arrays](https://www.lua.org/pil/19.1.html), this is a result of Lua table semantics, so when Redis converts a Lua array into Redis protocol the conversion is stopped if a nil is encountered.
 
 Here are a few conversion examples:
 

--- a/commands/expireat.md
+++ b/commands/expireat.md
@@ -2,7 +2,7 @@
 specifying the number of seconds representing the TTL (time to live), it takes
 an absolute [Unix timestamp][hewowu] (seconds since January 1, 1970).
 
-[hewowu]: http://en.wikipedia.org/wiki/Unix_time
+[hewowu]: https://en.wikipedia.org/wiki/Unix_time
 
 Please for the specific semantics of the command refer to the documentation of
 `EXPIRE`.

--- a/commands/info.md
+++ b/commands/info.md
@@ -207,4 +207,4 @@ For each database, the following line is added:
 
 *   `dbXXX`:keys=XXX,expires=XXX
 
-[hcgcpgp]: http://code.google.com/p/google-perftools/
+[hcgcpgp]: https://code.google.com/p/google-perftools/

--- a/tools.json
+++ b/tools.json
@@ -93,7 +93,7 @@
   {
     "name": "Meerkat",
     "language": "Ruby",
-    "repository": "http://carlhoerberg.github.com/meerkat/",
+    "repository": "https://carlhoerberg.github.com/meerkat/",
     "description": "Rack middleware for Server Sent Events with multiple backends.",
     "authors": ["carlhoerberg"]
   },
@@ -135,7 +135,7 @@
   {
     "name": "Webdis",
     "language": "C",
-    "url": "http://webd.is/",
+    "url": "https://webd.is/",
     "repository": "https://github.com/nicolasff/webdis",
     "description": "A Redis HTTP interface with JSON output.",
     "authors": ["yowgi"]
@@ -164,14 +164,14 @@
   {
     "name": "Sidekiq",
     "language": "Ruby",
-    "repository": "http://mperham.github.com/sidekiq/",
+    "repository": "https://mperham.github.com/sidekiq/",
     "description": "Simple, efficient message processing for your Rails 3 application.",
     "authors": ["mperham"]
   },
   {
     "name": "Omhiredis",
     "language": "C",
-    "repository": "http://www.rsyslog.com/doc/build_from_repo.html",
+    "repository": "https://www.rsyslog.com/doc/build_from_repo.html",
     "description": "redis output plugin for rsyslog (rsyslog dev, and rsyslog head).",
     "authors": ["taotetek"]
   },
@@ -241,7 +241,7 @@
   {
     "name": "Redback",
     "language": "Javascript",
-    "repository": "http://github.com/chriso/redback",
+    "repository": "https://github.com/chriso/redback",
     "description": "Higher-level Redis constructs - social graph, full text search, rate limiting, key pairs.",
     "authors": ["chris6F"]
   },
@@ -262,16 +262,16 @@
   {
     "name": "Redis Qi4j EntityStore",
     "language": "Java",
-    "url": "http://qi4j.org/extension-es-redis.html",
-    "repository": "http://github.com/qi4j/qi4j-sdk",
+    "url": "https://polygene.apache.org/extension-es-redis.html",
+    "repository": "https://github.com/qi4j/qi4j-sdk",
     "description": "Qi4j EntityStore backed by Redis",
     "authors": ["eskatos"]
   },
   {
     "name": "Spring Data Redis",
     "language": "Java",
-    "url": "http://www.springsource.org/spring-data/redis",
-    "repository": "http://github.com/SpringSource/spring-data-redis",
+    "url": "https://www.springsource.org/spring-data/redis",
+    "repository": "https://github.com/SpringSource/spring-data-redis",
     "description": "Spring integration for Redis promoting POJO programming, portability and productivity",
     "authors": ["costinl"]
   }

--- a/topics/benchmarks.md
+++ b/topics/benchmarks.md
@@ -103,11 +103,11 @@ connections, the comparison is actually meaningful.
 This perfect example is illustrated by the dialog between Redis (antirez) and
 memcached (dormando) developers.
 
-[antirez 1 - On Redis, Memcached, Speed, Benchmarks and The Toilet](http://antirez.com/post/redis-memcached-benchmark.html)
+[antirez 1 - On Redis, Memcached, Speed, Benchmarks and The Toilet](http://oldblog.antirez.com/post/redis-memcached-benchmark.html)
 
-[dormando - Redis VS Memcached (slightly better bench)](http://dormando.livejournal.com/525147.html)
+[dormando - Redis VS Memcached (slightly better bench)](https://dormando.livejournal.com/525147.html)
 
-[antirez 2 - An update on the Memcached/Redis benchmark](http://antirez.com/post/update-on-memcached-redis-benchmark.html)
+[antirez 2 - An update on the Memcached/Redis benchmark](http://oldblog.antirez.com/post/update-on-memcached-redis-benchmark.html)
 
 You can see that in the end, the difference between the two solutions is not
 so staggering, once all technical aspects are considered. Please note both

--- a/topics/clients.md
+++ b/topics/clients.md
@@ -153,11 +153,11 @@ In the above example session two clients are connected to the Redis server. The 
 * **name**: The client name as set by `CLIENT SETNAME`.
 * **age**: The number of seconds the connection existed for.
 * **idle**: The number of seconds the connection is idle.
-* **flags**: The kind of client (N means normal client, check the [full list of flags](http://redis.io/commands/client-list)).
+* **flags**: The kind of client (N means normal client, check the [full list of flags](https://redis.io/commands/client-list)).
 * **omem**: The amount of memory used by the client for the output buffer.
 * **cmd**: The last executed command.
 
-See the [CLIENT LIST](http://redis.io/commands/client-list) documentation for the full list of fields and their meaning.
+See the [CLIENT LIST](https://redis.io/commands/client-list) documentation for the full list of fields and their meaning.
 
 Once you have the list of clients, you can easily close the connection with a client using the `CLIENT KILL` command specifying the client address as argument.
 

--- a/topics/data-types-intro.md
+++ b/topics/data-types-intro.md
@@ -181,7 +181,7 @@ submitted links (news) to the list is the following:
     (integer) 1
     $ redis-cli set news:1:title "Redis is simple"
     OK
-    $ redis-cli set news:1:url "http://code.google.com/p/redis"
+    $ redis-cli set news:1:url "https://code.google.com/p/redis"
     OK
     $ redis-cli lpush submitted.news 1
     OK

--- a/topics/debugging.md
+++ b/topics/debugging.md
@@ -71,7 +71,7 @@ In order to attach GDB the first thing you need is the *process ID* of the runni
 In the above example the process ID is **58414**.
 
 + Login into your Redis server.
-+ (Optional but recommended) Start **screen** or **tmux** or any other program that will make sure that your GDB session will not be closed if your ssh connection will timeout. If you don't know what screen is do yourself a favour and [Read this article](http://www.linuxjournal.com/article/6340)
++ (Optional but recommended) Start **screen** or **tmux** or any other program that will make sure that your GDB session will not be closed if your ssh connection will timeout. If you don't know what screen is do yourself a favour and [Read this article](https://www.linuxjournal.com/article/6340)
 + Attach GDB to the running Redis server typing:
 
     gdb `<path-to-redis-executable>` `<pid>`
@@ -182,4 +182,4 @@ Finally you can send everything to the Redis core team:
 Thank you
 ---------
 
-Your help is extremely important! Many issues can only be tracked this way, thanks! It is also possible that helping Redis debugging you'll be among the winners of the next [Redis Moka Award](http://antirez.com/post/redis-moka-awards-2011.html).
+Your help is extremely important! Many issues can only be tracked this way, thanks! It is also possible that helping Redis debugging you'll be among the winners of the next [Redis Moka Award](http://oldblog.antirez.com/post/redis-moka-awards-2011.html).

--- a/topics/faq.md
+++ b/topics/faq.md
@@ -95,7 +95,7 @@ A good source to understand how Linux Virtual Memory work and other
 alternatives for `overcommit_memory` and `overcommit_ratio` is this classic
 from Red Hat Magazine, ["Understanding Virtual Memory"][redhatvm].
 
-[redhatvm]: http://www.redhat.com/magazine/001nov04/features/vm/
+[redhatvm]: https://www.redhat.com/magazine/001nov04/features/vm/
 
 ## Are Redis on-disk-snapshots atomic?
 
@@ -137,4 +137,4 @@ It means REmote DIctionary Server.
 
 Originally Redis was started in order to scale [LLOOGG][lloogg]. But after I got the basic server working I liked the idea to share the work with other guys, and Redis was turned into an open source project.
 
-[lloogg]: http://lloogg.com
+[lloogg]: https://lloogg.com

--- a/topics/internals-eventlib.md
+++ b/topics/internals-eventlib.md
@@ -9,7 +9,7 @@ Let us figure it out through a series of Q&As.
 Q: What do you expect a network server to be doing all the time? <br/>
 A: Watch for inbound connections on the port its listening and accept them.
 
-Q: Calling [accept](http://man.cx/accept%282%29 accept) yields a descriptor. What do I do with it?<br/>
+Q: Calling [accept](https://man.cx/accept%282%29 accept) yields a descriptor. What do I do with it?<br/>
 A: Save the descriptor and do a non-blocking read/write operation on it.
 
 Q: Why does the read/write have to be non-blocking?<br/>
@@ -25,4 +25,4 @@ Q: So are there any open source event libraries that do what you just described?
 A: Yes. `libevent` and `libev` are two such event libraries that I can recall off the top of my head.
 
 Q: Does Redis use such open source event libraries for handling socket I/O?<br/>
-A: No. For various [reasons](http://groups.google.com/group/redis-db/browse_thread/thread/b52814e9ef15b8d0/) Redis uses its own event library.
+A: No. For various [reasons](https://groups.google.com/group/redis-db/browse_thread/thread/b52814e9ef15b8d0/) Redis uses its own event library.

--- a/topics/internals-rediseventlib.md
+++ b/topics/internals-rediseventlib.md
@@ -31,7 +31,7 @@ Event Loop Initialization
 
 `aeCreateEventLoop` first `malloc`s `aeEventLoop` structure then calls `ae_epoll.c:aeApiCreate`.
 
-`aeApiCreate` `malloc`s `aeApiState` that has two fields - `epfd` that holds the `epoll` file descriptor returned by a call from [`epoll_create`](http://man.cx/epoll_create%282%29) and `events` that is of type `struct epoll_event` define by the Linux `epoll` library. The use of the `events` field will be  described later.
+`aeApiCreate` `malloc`s `aeApiState` that has two fields - `epfd` that holds the `epoll` file descriptor returned by a call from [`epoll_create`](https://man.cx/epoll_create%282%29) and `events` that is of type `struct epoll_event` define by the Linux `epoll` library. The use of the `events` field will be  described later.
 
 Next is `ae.c:aeCreateTimeEvent`. But before that `initServer` call `anet.c:anetTcpServer` that creates and returns a _listening descriptor_. The descriptor listens on *port 6379* by default. The returned  _listening descriptor_ is stored in `server.fd` field.
 
@@ -55,7 +55,7 @@ Next is `ae.c:aeCreateTimeEvent`. But before that `initServer` call `anet.c:anet
 `aeCreateFileEvent`
 ---
 
-The essence of `aeCreateFileEvent` function is to execute [`epoll_ctl`](http://man.cx/epoll_ctl) system call which adds a watch for `EPOLLIN` event on the _listening descriptor_ create by `anetTcpServer` and associate it with the `epoll` descriptor created by a call to `aeCreateEventLoop`.
+The essence of `aeCreateFileEvent` function is to execute [`epoll_ctl`](https://man.cx/epoll_ctl) system call which adds a watch for `EPOLLIN` event on the _listening descriptor_ create by `anetTcpServer` and associate it with the `epoll` descriptor created by a call to `aeCreateEventLoop`.
 
 Following is an explanation of what precisely `aeCreateFileEvent` does when called from `redis.c:initServer`.
 
@@ -84,14 +84,14 @@ Remember, that timer event created by `aeCreateTimeEvent` has by now probably el
 
 The `tvp` structure variable along with the event loop variable is passed to `ae_epoll.c:aeApiPoll`.
 
-`aeApiPoll` functions does a [`epoll_wait`](http://man.cx/epoll_wait) on the `epoll` descriptor and populates the `eventLoop->fired` table with the details:
+`aeApiPoll` functions does a [`epoll_wait`](https://man.cx/epoll_wait) on the `epoll` descriptor and populates the `eventLoop->fired` table with the details:
 
   * `fd`: The descriptor that is now ready to do a read/write operation depending on the mask value.
   * `mask`: The read/write event that can now be performed on the corresponding descriptor.
 
 `aeApiPoll` returns the number of such file events ready for operation. Now to put things in context, if any client has requested for a connection then `aeApiPoll` would have noticed it and populated the `eventLoop->fired` table with an entry of the descriptor being the _listening descriptor_ and mask being `AE_READABLE`.
 
-Now, `aeProcessEvents` calls the `redis.c:acceptHandler` registered as the callback. `acceptHandler` executes [accept](http://man.cx/accept) on the _listening descriptor_ returning a _connected descriptor_ with the client. `redis.c:createClient` adds a file event on the _connected descriptor_ through a call to `ae.c:aeCreateFileEvent` like below:
+Now, `aeProcessEvents` calls the `redis.c:acceptHandler` registered as the callback. `acceptHandler` executes [accept](https://man.cx/accept) on the _listening descriptor_ returning a _connected descriptor_ with the client. `redis.c:createClient` adds a file event on the _connected descriptor_ through a call to `ae.c:aeCreateFileEvent` like below:
 
     if (aeCreateFileEvent(server.el, c->fd, AE_READABLE,
         readQueryFromClient, c) == AE_ERR) {

--- a/topics/introduction.md
+++ b/topics/introduction.md
@@ -36,5 +36,5 @@ You can use Redis from [most programming languages](/clients) out there.
 Redis is written in **ANSI C** and works in most POSIX systems like Linux,
 \*BSD, OS X without external dependencies. Linux and OSX are the two operating systems where Redis is developed and more tested, and we **recommend using Linux for deploying**. Redis may work in Solaris-derived systems like SmartOS, but the support is *best effort*. There
 is no official support for Windows builds, although you may
-have [some](http://code.google.com/p/redis/issues/detail?id=34)
+have [some](https://code.google.com/p/redis/issues/detail?id=34)
 [options](https://github.com/dmajkic/redis).

--- a/topics/latency.md
+++ b/topics/latency.md
@@ -522,7 +522,7 @@ Now, if you run older distributions (RH 5, SLES 10-11, or derivatives), and
 not afraid of a few hacks, Redis requires to be patched in order to support
 huge pages.
 
-The first step would be to read [Mel Gorman's primer on huge pages](http://lwn.net/Articles/374424/)
+The first step would be to read [Mel Gorman's primer on huge pages](https://lwn.net/Articles/374424/)
 
 There are currently two ways to patch Redis to support huge pages.
 

--- a/topics/license.md
+++ b/topics/license.md
@@ -38,7 +38,7 @@ Redis uses source code from third parties. All this code contians a BSD or BSD-c
 
 * Redis uses the `sha1.c` file that is copyright by Steve Reid and released under the **public domain**. This file is extremely popular and used among open source and proprietary code.
 
-* When compiled on Linux Redis usees the [Jemalloc allocator](http://www.canonware.com/jemalloc/), that is copyright by Jason Evans, Mozilla Foundation and Facebook, Inc and is released under the **two clause BSD license**.
+* When compiled on Linux Redis usees the [Jemalloc allocator](https://www.canonware.com/jemalloc/), that is copyright by Jason Evans, Mozilla Foundation and Facebook, Inc and is released under the **two clause BSD license**.
 
 * Inside Jemalloc the file `pprof` is copyright Google Inc and released under the **three clause BSD license**.
 

--- a/topics/partitioning.md
+++ b/topics/partitioning.md
@@ -114,4 +114,4 @@ Clients supporting consistent hashing
 
 An alternative to Twemproxy is to use a client that implements client side partitioning via consistent hashing or other similar algorithms. There are multiple Redis clients with support for consistent hashing, notably [Redis-rb](https://github.com/redis/redis-rb) and [Predis](https://github.com/nrk/predis).
 
-Please check the [full list of Redis clients](http://redis.io/clients) to check if there is a mature client with consistent hashing implementation for your language.
+Please check the [full list of Redis clients](https://redis.io/clients) to check if there is a mature client with consistent hashing implementation for your language.

--- a/topics/persistence.md
+++ b/topics/persistence.md
@@ -1,4 +1,4 @@
-This page provides a technical description of Redis persistence, it is a suggested read for all the Redis users. For a wider overview of Redis persistence and the durability guarantees it provides you may want to also read [Redis persistence demystified](http://antirez.com/post/redis-persistence-demystified.html).
+This page provides a technical description of Redis persistence, it is a suggested read for all the Redis users. For a wider overview of Redis persistence and the durability guarantees it provides you may want to also read [Redis persistence demystified](http://oldblog.antirez.com/post/redis-persistence-demystified.html).
 
 Redis Persistence
 ===
@@ -79,7 +79,7 @@ This strategy is known as _snapshotting_.
 
 Whenever Redis needs to dump the dataset to disk, this is what happens:
 
-* Redis [forks](http://linux.die.net/man/2/fork). We now have a child
+* Redis [forks](https://linux.die.net/man/2/fork). We now have a child
 and a parent process.
 
 * The child starts to write the dataset to a temporary RDB file.
@@ -129,7 +129,7 @@ time. Redis 2.4 is able to trigger log rewriting automatically (see the
 ### How durable is the append only file?
 
 You can configure how many times Redis will
-[`fsync`](http://linux.die.net/man/2/fsync) data on disk. There are
+[`fsync`](https://linux.die.net/man/2/fsync) data on disk. There are
 three options:
 
 * `fsync` every time a new command is appended to the AOF. Very very
@@ -169,7 +169,7 @@ files.
 Log rewriting uses the same copy-on-write trick already in use for
 snapshotting.  This is how it works:
 
-* Redis [forks](http://linux.die.net/man/2/fork), so now we have a child
+* Redis [forks](https://linux.die.net/man/2/fork), so now we have a child
 and a parent process.
 
 * The child starts writing the new AOF in a temporary file.

--- a/topics/pipelining.md
+++ b/topics/pipelining.md
@@ -105,4 +105,4 @@ Pipelining VS Scripting
 
 Using [Redis scripting](/commands/eval) (available in Redis version 2.6 or greater) a number of use cases for pipelining can be addressed more efficiently using scripts that perform a lot of the work needed server side. A big advantage of scripting is that it is able to both read and write data with minimal latency, making operations like *read, compute, write* very fast (pipelining can't help in this scenario since the client needs the reply of the read command before it can call the write command).
 
-Sometimes the application may also want to send `EVAL` or `EVALSHA` commands in a pipeline. This is entirely possible and Redis explicitly supports it with the [SCRIPT LOAD](http://redis.io/commands/script-load) command (it guarantees that `EVALSHA` can be called without the risk of failing).
+Sometimes the application may also want to send `EVAL` or `EVALSHA` commands in a pipeline. This is entirely possible and Redis explicitly supports it with the [SCRIPT LOAD](https://redis.io/commands/script-load) command (it guarantees that `EVALSHA` can be called without the risk of failing).

--- a/topics/problems.md
+++ b/topics/problems.md
@@ -5,9 +5,9 @@ This page tries to help you about what to do if you have issues with Redis. Part
 
 * If you have **latency problems** with Redis, that in some way appears to be idle for some time, read our [Redis latency trubleshooting guide](/topics/latency).
 * Redis stable releases are usually very reliable, however in the rare event you are **experiencing crashes** the developers can help a lot more if you provide debugging informations. Please read our [Debugging Redis guide](/topics/debugging).
-* It happened multiple times that users experiencing problems with Redis actually had a server with **broken RAM**. Please test your RAM using **redis-server --test-memory** in case Redis is not stable in your system. Redis built-in memory test is fast and reasonably reliable, but if you can you should reboot your server and use [memtest86](http://memtest86.com).
+* It happened multiple times that users experiencing problems with Redis actually had a server with **broken RAM**. Please test your RAM using **redis-server --test-memory** in case Redis is not stable in your system. Redis built-in memory test is fast and reasonably reliable, but if you can you should reboot your server and use [memtest86](https://memtest86.com).
 
-For every other problem please drop a message to the [Redis Google Group](http://groups.google.com/group/redis-db). We will be glad to help.
+For every other problem please drop a message to the [Redis Google Group](https://groups.google.com/group/redis-db). We will be glad to help.
 
 List of known critical bugs in previous Redis releases.
 ===
@@ -15,13 +15,13 @@ List of known critical bugs in previous Redis releases.
 Note: this list may not be complete as we staretd it March 30, 2012, and did not included much historical data.
 
 * Redis version up to 2.4.12 and 2.6.0-RC1: KEYS may not list all the keys, or may list duplicated keys, if keys with an expire set are present in the database. [Issue #487](https://github.com/antirez/redis/pull/487).
-* Redis version up to 2.4.10: SORT using GET or BY option with keys with an expire set may crash the server. [Issue #460](http://github.com/antirez/redis/issues/460).
-* Redis version up to 2.4.10: a bug in the aeWait() implementation in ae.c may result in a server crash under extremely hard to replicate conditions. [Issue #267](http://github.com/antirez/redis/issues/267).
+* Redis version up to 2.4.10: SORT using GET or BY option with keys with an expire set may crash the server. [Issue #460](https://github.com/antirez/redis/issues/460).
+* Redis version up to 2.4.10: a bug in the aeWait() implementation in ae.c may result in a server crash under extremely hard to replicate conditions. [Issue #267](https://github.com/antirez/redis/issues/267).
 * Redis version up to 2.4.9: **memory leak in replication**. A memory leak was triggered by replicating a master contaning a database ID greatear than ID 9.
 * Redis version up to 2.4.9: **chained replication bug**. In environments where a slave B is attached to another instance `A`, and the instance `A` is switched between master and slave using the `SLAVEOF` command, it is possilbe that `B` will not be correctly disconnected to force a resync when `A` changes status (and data set content).
 * Redis version up to 2.4.7: **redis-check-aof does not work properly in 32 bit instances with AOF files bigger than 2GB**.
 * Redis version up to 2.4.7: **Mixing replication and maxmemory produced bad results**. Specifically a master with maxmemory set with attached slaves could result into the master blocking and the dataset on the master to get completely erased. The reason was that key expiring produced more memory usabe because of the replication link DEL synthesizing, triggering the expiring of more keys.
-* Redis versions up to 2.4.5: **Connection of multiple slaves at the same time could result into big master memory usage, and slave desync**. (See [issue 141](http://github.com/antirez/redis/issues/141) for more details).
+* Redis versions up to 2.4.5: **Connection of multiple slaves at the same time could result into big master memory usage, and slave desync**. (See [issue 141](https://github.com/antirez/redis/issues/141) for more details).
 
 List of known bugs still present in latest 2.4 release.
 ===

--- a/topics/pubsub.md
+++ b/topics/pubsub.md
@@ -3,7 +3,7 @@ Pub/Sub
 
 `SUBSCRIBE`, `UNSUBSCRIBE` and `PUBLISH`
 implement the [Publish/Subscribe messaging
-paradigm](http://en.wikipedia.org/wiki/Publish/subscribe) where
+paradigm](https://en.wikipedia.org/wiki/Publish/subscribe) where
 (citing Wikipedia) senders (publishers) are not programmed to send
 their messages to specific receivers (subscribers). Rather, published
 messages are characterized into channels, without knowledge of what (if

--- a/topics/quickstart.md
+++ b/topics/quickstart.md
@@ -19,7 +19,7 @@ Redis has no dependencies other than a working GCC compiler and libc.
 Installing it using the package manager of your Linux distribution is somewhat
 discouraged as usually the available version is not the latest.
 
-You can either download the latest Redis tar ball from the [redis.io](http://redis.io) web site, or you can alternatively use this special URL that always points to the latest stable Redis version, that is, [http://download.redis.io/redis-stable.tar.gz](http://download.redis.io/redis-stable.tar.gz).
+You can either download the latest Redis tar ball from the [redis.io](https://redis.io) web site, or you can alternatively use this special URL that always points to the latest stable Redis version, that is, [http://download.redis.io/redis-stable.tar.gz](http://download.redis.io/redis-stable.tar.gz).
 
 In order to compile Redis follow this simple steps:
 
@@ -80,7 +80,7 @@ Another interesting way to run redis-cli is without arguments: the program will 
     redis 127.0.0.1:6379> get mykey
     "somevalue"
 
-At this point you can talk with Redis. It is the right time to pause a bit with this tutorial and start the [fifteen minutes introduction to Redis data types](http://redis.io/topics/data-types-intro) in order to learn a few Redis commands. Otherwise if you already know a few basic Redis commands you can keep reading.
+At this point you can talk with Redis. It is the right time to pause a bit with this tutorial and start the [fifteen minutes introduction to Redis data types](https://redis.io/topics/data-types-intro) in order to learn a few Redis commands. Otherwise if you already know a few basic Redis commands you can keep reading.
 
 Using Redis from your application
 ===
@@ -88,10 +88,10 @@ Using Redis from your application
 Of course using Redis just from the command line interface is not enough as
 the goal is to use it from your application. In order to do so you need to
 download and install a Redis client library for your programming language.
-You'll find a [full list of clients for different languages in this page](http://redis.io/clients).
+You'll find a [full list of clients for different languages in this page](https://redis.io/clients).
 
 For instance if you happen to use the Ruby programming language our best advice
-is to use the [Redis-rb](http://github.com/ezmobius/redis-rb) client.
+is to use the [Redis-rb](https://github.com/ezmobius/redis-rb) client.
 You can install it using the command **gem install redis** (also make sure to install the **SystemTimer** gem as well).
 
 These instructions are Ruby specific but actually many library clients for
@@ -114,12 +114,12 @@ commands calling methods. A short interactive example using Ruby:
 Redis persistence
 =================
 
-You can learn [how Redis persisence works in this page](http://redis.io/topics/persistence), however what is important to understand for a quick start is that by default, if you start Redis with the default configuration, Redis will spontaneously save the dataset only from time to time (for instance after at least five minutes if you have at least 100 changes in your data), so if you want your database to persist and be reloaded after a restart make sure to call the **SAVE** command manually every time you want to force a data set snapshot. Otherwise make sure to shutdown the database using the **SHUTDOWN** command:
+You can learn [how Redis persisence works in this page](https://redis.io/topics/persistence), however what is important to understand for a quick start is that by default, if you start Redis with the default configuration, Redis will spontaneously save the dataset only from time to time (for instance after at least five minutes if you have at least 100 changes in your data), so if you want your database to persist and be reloaded after a restart make sure to call the **SAVE** command manually every time you want to force a data set snapshot. Otherwise make sure to shutdown the database using the **SHUTDOWN** command:
 
     $ redis-cli shutdown
 
 This way Redis will make sure to save the data on disk before quitting.
-Reading the [persistence page](http://redis.io/topics/persistence) is strongly suggested in order to better understand how Redis persistence works.
+Reading the [persistence page](https://redis.io/topics/persistence) is strongly suggested in order to better understand how Redis persistence works.
 
 Installing Redis more properly
 ==============================

--- a/topics/sponsors.md
+++ b/topics/sponsors.md
@@ -1,22 +1,22 @@
 Redis Sponsors
 ===
 
-All the work [Salvatore Sanfilippo](http://twitter.com/antirez) and [Pieter Noordhuis](http://twitter.com/pnoordhuis) are doing in order to develop Redis is sponsored by [VMware](http://vmware.com). The Redis project no longer accepts money donations.
+All the work [Salvatore Sanfilippo](https://twitter.com/antirez) and [Pieter Noordhuis](https://twitter.com/pnoordhuis) are doing in order to develop Redis is sponsored by [VMware](https://vmware.com). The Redis project no longer accepts money donations.
 
 In the past Redis accepted donations from the following companies:
 
-* [Linode](http://linode.com) 15 January 2010, provided Virtual Machines for Redis testing in a virtualized environment.
-* [Slicehost](http://slicehost.com) 14 January 2010, provided Virtual Machines for Redis testing in a virtualized environment.
-* [Citrusbyte](http://citrusbyte.com) 18 Dec 2009, part of Virtual Memory. Citrusbyte is also the company developing the Redis-rb bindings for Redis and this very web site.
-* [Hitmeister](http://www.hitmeister.de/) 15 Dec 2009, part of Redis Cluster.
-* [Engine Yard](http://engineyard.com) 13 Dec 2009, for blocking POP (BLPOP) and part of the Virtual Memory implementation.
+* [Linode](https://linode.com) 15 January 2010, provided Virtual Machines for Redis testing in a virtualized environment.
+* [Slicehost](https://www.rackspace.com/cloud/vps/) 14 January 2010, provided Virtual Machines for Redis testing in a virtualized environment.
+* [Citrusbyte](https://citrusbyte.com) 18 Dec 2009, part of Virtual Memory. Citrusbyte is also the company developing the Redis-rb bindings for Redis and this very web site.
+* [Hitmeister](https://www.hitmeister.de/) 15 Dec 2009, part of Redis Cluster.
+* [Engine Yard](https://engineyard.com) 13 Dec 2009, for blocking POP (BLPOP) and part of the Virtual Memory implementation.
 
 Also thanks to the following people or organizations that donated to the Project:
 
 * Emil Vladev
-* [Brad Jasper](http://bradjasper.com/)
-* [Mrkris](http://www.mrkris.com/)
+* [Brad Jasper](https://bradjasper.com/)
+* [Mrkris](https://www.mrkris.com/)
 
-We are grateful to [VMware](http://vmware.com) and to the companies and people that donated to the Redis project. Thank you.
+We are grateful to [VMware](https://vmware.com) and to the companies and people that donated to the Redis project. Thank you.
 
-The Redis.io domain is kindly donated to the project by [I Want My Name](http://iwantmyname.com).
+The Redis.io domain is kindly donated to the project by [I Want My Name](https://iwantmyname.com).

--- a/topics/transactions.md
+++ b/topics/transactions.md
@@ -199,7 +199,7 @@ the transaction only if no other client modified any of the
 `WATCH`ed keys. Otherwise the transaction is not entered at
 all. (Note that if you `WATCH` a volatile key and Redis expires
 the key after you `WATCH`ed it, `EXEC` will still work. [More on
-this](http://code.google.com/p/redis/issues/detail?id=270).)
+this](https://code.google.com/p/redis/issues/detail?id=270).)
 
 `WATCH` can be called multiple times. Simply all the `WATCH` calls will
 have the effects to watch for changes starting from the call, up to

--- a/topics/twitter-clone.md
+++ b/topics/twitter-clone.md
@@ -1,24 +1,24 @@
 A case study: Design and implementation of a simple Twitter clone using only the Redis key-value store as database and PHP
 ===
 
-In this article I'll explain the design and the implementation of a [simple clone of Twitter](http://retwis.antirez.com) written using PHP and Redis as only database. The programming community uses to look at key-value stores like special databases that can't be used as drop in replacement for a relational database for the development of web applications. This article will try to prove the contrary.
+In this article I'll explain the design and the implementation of a [simple clone of Twitter](http://retwis.redis.io) written using PHP and Redis as only database. The programming community uses to look at key-value stores like special databases that can't be used as drop in replacement for a relational database for the development of web applications. This article will try to prove the contrary.
 
-Our Twitter clone, [called Retwis](http://retwis.antirez.com), is structurally simple, has very good performance, and can be distributed among N web servers and M Redis servers with very little effort. You can find the source code [here](http://code.google.com/p/redis/downloads/list).
+Our Twitter clone, [called Retwis](http://retwis.redis.io), is structurally simple, has very good performance, and can be distributed among N web servers and M Redis servers with very little effort. You can find the source code [here](https://code.google.com/p/redis/downloads/list).
 
 We use PHP for the example since it can be read by everybody. The same (or... much better) results can be obtained using Ruby, Python, Erlang, and so on.
 
-**Note:** [Retwis-RB](http://retwisrb.danlucraft.com/) is a port of Retwis to
+**Note:** [Retwis-RB](https://retwisrb.danlucraft.com/) is a port of Retwis to
 Ruby and Sinatra written by Daniel Lucraft! With full source code included of
 course, the Git repository is linked in the footer of the web page. The rest
 of this article targets PHP, but Ruby programmers can also check the other
 source code, it conceptually very similar.
 
-**Note:** [Retwis-J](http://retwisj.cloudfoundry.com/) is a port of Retwis to
-Java, using the Spring Data Framework, written by [Costin Leau](http://twitter.com/costinl). The source code
+**Note:** [Retwis-J](https://retwisj.cloudfoundry.com/) is a port of Retwis to
+Java, using the Spring Data Framework, written by [Costin Leau](https://twitter.com/costinl). The source code
 can be found on
 [GitHub](https://github.com/SpringSource/spring-data-keyvalue-examples) and
 there is comprehensive documentation available at
-[springsource.org](http://j.mp/eo6z6I).
+[springsource.org](https://j.mp/eo6z6I).
 
 Key-value stores basics
 ---
@@ -77,7 +77,7 @@ LRANGE uses zero-based indexes, that is the first element is 0, the second 1, an
 
     LRANGE mylist 0 -1 => c,b,a
 
-Other important operations are LLEN that returns the length of the list, and LTRIM that is like LRANGE but instead of returning the specified range *trims* the list, so it is like _Get range from mylist, Set this range as new value_ but atomic. We will use only this List operations, but make sure to check the [Redis documentation](http://code.google.com/p/redis/wiki/README) to discover all the List operations supported by Redis.
+Other important operations are LLEN that returns the length of the list, and LTRIM that is like LRANGE but instead of returning the specified range *trims* the list, so it is like _Get range from mylist, Set this range as new value_ but atomic. We will use only this List operations, but make sure to check the [Redis documentation](https://code.google.com/p/redis/wiki/README) to discover all the List operations supported by Redis.
 
 The set data type
 ---
@@ -108,7 +108,7 @@ Okay, I think we are ready to start coding!
 Prerequisites
 ---
 
-If you didn't download it already please grab the [source code of Retwis](http://code.google.com/p/redis/downloads/list). It's a simple tar.gz file with a few of PHP files inside. The implementation is very simple. You will find the PHP library client inside (redis.php) that is used to talk with the Redis server from PHP. This library was written by [Ludovico Magnocavallo](http://qix.it) and you are free to reuse this in your own projects, but for updated version of the library please download the Redis distribution. (Note: there are now better PHP libraries available, check our [clients page](/clients).
+If you didn't download it already please grab the [source code of Retwis](https://code.google.com/p/redis/downloads/list). It's a simple tar.gz file with a few of PHP files inside. The implementation is very simple. You will find the PHP library client inside (redis.php) that is used to talk with the Redis server from PHP. This library was written by [Ludovico Magnocavallo](http://qix.it) and you are free to reuse this in your own projects, but for updated version of the library please download the Redis distribution. (Note: there are now better PHP libraries available, check our [clients page](/clients).
 
 Another thing you probably want is a working Redis server. Just get the source, compile with make, and run with ./redis-server and you are done. No configuration is required at all in order to play with it or to run Retwis in your computer.
 

--- a/topics/virtual-memory.md
+++ b/topics/virtual-memory.md
@@ -8,7 +8,7 @@ stable Redis distribution in Redis 2.0. However Virtual Memory (called VM
 starting from now) is already available and stable enough to be tests in the
 unstable branch of Redis available [on Git][redissrc].
 
-[redissrc]: http://github.com/antirez/redis
+[redissrc]: https://github.com/antirez/redis
 
 ## Virtual Memory explained in simple words
 
@@ -183,7 +183,7 @@ Redis process while creating a very big file at once.
 For a list of file systems supporting spare files, [check this check this
 Wikipedia page comparing different files systems][wikifs].
 
-[wikifs]: http://en.wikipedia.org/wiki/Comparison_of_file_systems
+[wikifs]: https://en.wikipedia.org/wiki/Comparison_of_file_systems
 
 ## Monitoring the VM
 
@@ -192,7 +192,7 @@ interested to know how it's working: how many objects are swapped in total,
 the number of objects swapped and loaded every second, and so forth.
 
 There is an utility that is very handy in checking how the VM is working, that
-is part of [Redis Tools](http://github.com/antirez/redis-tools). This tool is
+is part of [Redis Tools](https://github.com/antirez/redis-tools). This tool is
 called redis-stat, and using it is pretty straightforward:
 
     $ ./redis-stat vmstat

--- a/topics/whos-using-redis.md
+++ b/topics/whos-using-redis.md
@@ -5,7 +5,7 @@ Logos are linked to the relevant story when available.
 
 <ul>
   <li>
-    <img src="http://www.engineyard.com/images/logo.png" alt="EngineYard">
+    <img src="https://www.engineyard.com/images/logo.png" alt="EngineYard">
   </li>
 
   <li>
@@ -17,36 +17,36 @@ Logos are linked to the relevant story when available.
   </li>
 
   <li>
-    <a href="http://simonwillison.net/2009/Dec/20/crowdsourcing"><img src="http://static.guim.co.uk/static/97665/networkfront/images/guardian_logo.png" alt="The Guardian"></a>
+    <a href="https://simonwillison.net/2009/Dec/20/crowdsourcing"><img src="https://static.guim.co.uk/static/97665/networkfront/images/guardian_logo.png" alt="The Guardian"></a>
   </li>
 
   <li>
-    <img src="http://static.mlstatic.com/org-img/logo_ml/logoAlpha.png" alt="MercadoLibre">
+    <img src="https://static.mlstatic.com/org-img/logo_ml/logoAlpha.png" alt="MercadoLibre">
   </li>
 
   <li>
-    <img src="http://us.blizzard.com/_images/company/about/awards/logo-dev.gif" alt="Blizzard" width="100">
+    <img src="https://us.blizzard.com/_images/company/about/awards/logo-dev.gif" alt="Blizzard" width="100">
   </li>
 
   <li>
-    <img src="http://developers.diggstatic.com/sites/all/themes/about/img/footer_logo.jpg" alt="Digg">
+    <img src="https://developers.diggstatic.com/sites/all/themes/about/img/footer_logo.jpg" alt="Digg">
   </li>
 
   <li>
-    <img src="http://static.pe.studivz.net/20101222-0/Img/logo.png" alt="StudiVZ">
+    <img src="https://static.pe.studivz.net/20101222-0/Img/logo.png" alt="StudiVZ">
   </li>
 
   <li>
-    <a href="http://bretthoerner.com/2011/2/21/redis-at-disqus/"><img style="background-color:#4e7ba3; padding:10px;" src="http://mediacdn.disqus.com/1294274648/img/disqus-logo.png" alt="Disqus"></a>
+    <a href="https://bretthoerner.com/2011/2/21/redis-at-disqus/"><img style="background-color:#4e7ba3; padding:10px;" src="https://a.disquscdn.com/1294274648/img/disqus-logo.png" alt="Disqus"></a>
   </li>
 
   <li>
-    <a href="http://meta.stackoverflow.com/questions/69164/does-stackoverflow-use-caching-and-if-so-how/69172"><img src="http://sstatic.net/stackoverflow/img/logo.png" alt="Stack Overflow"></a>
+    <a href="https://meta.stackoverflow.com/questions/69164/does-stackoverflow-use-caching-and-if-so-how/69172"><img src="https://sstatic.net/stackoverflow/img/logo.png" alt="Stack Overflow"></a>
   </li>
 
   <li>
     <!-- https://github.com/antirez/redis-doc/issues#issue/8 //-->
-    <img src="http://www.tweetdeck.com/assets/logo/UpdatedLogo-500x500.png" alt="Tweetdeck">
+    <img src="https://www.tweetdeck.com/assets/logo/UpdatedLogo-500x500.png" alt="Tweetdeck">
   </li>
 
   <li>
@@ -54,51 +54,51 @@ Logos are linked to the relevant story when available.
   </li>
 
   <li>
-    <a href="http://code.flickr.com/blog/2011/10/11/talk-real-time-updates-on-the-cheap-for-fun-and-profit/"><img src="http://l.yimg.com/g/images/en-us/flickr-yahoo-logo.png.v3" alt="Flickr"></a>
+    <a href="https://code.flickr.net/blog/2011/10/11/talk-real-time-updates-on-the-cheap-for-fun-and-profit/"><img src="http://l.yimg.com/g/images/en-us/flickr-yahoo-logo.png.v3" alt="Flickr"></a>
   </li>
 </ul>
 
 And many others:
 
-* [Superfeedr](http://blog.superfeedr.com/redis/mysql/memcache/datastore/performance/redis-at-superfeedr)
-* [Vidiowiki](http://vidiowiki.com)
-* [Wish Internet Consulting](http://wish.hu)
-* [Ruby Minds](http://rubyminds.com)
-* [Boxcar](http://www.boxcar.io)
-* [Zoombu](http://www.zoombu.co.uk)
-* [Dark Curse](http://www.darkcurse.com)
-* [OKNOtizie](http://oknotizie.virgilio.it)
-* [Moodstocks](http://www.moodstocks.com/2010/11/26/the-tech-behind-moodstocks-notes) uses Redis as its main database by means of [Ohm](http://ohm.keyvalue.org).
-* [Favstar](http://favstar.fm)
-* [Heywatch](http://heywatch.com)
-* [Sharpcloud](http://www.sharpcloud.com)
-* [Wooga](http://www.wooga.com/games/) for the games _"Happy Hospital"_ and _"Monster World"_.
-* [Sina Weibo](http://t.sina.com.cn/)
+* [Superfeedr](https://blog.superfeedr.com/redis/mysql/memcache/datastore/performance/redis-at-superfeedr)
+* [Vidiowiki](https://vidiowiki.com)
+* [Wish Internet Consulting](https://wish.hu)
+* [Ruby Minds](https://rubyminds.com)
+* [Boxcar](https://www.boxcar.io)
+* [Zoombu](https://www.zoombu.co.uk)
+* [Dark Curse](https://www.darkcurse.com)
+* [OKNOtizie](https://notizie.virgilio.it)
+* [Moodstocks](https://www.moodstocks.com/2010/11/26/the-tech-behind-moodstocks-notes) uses Redis as its main database by means of [Ohm](https://ohm.keyvalue.org).
+* [Favstar](https://favstar.fm)
+* [Heywatch](https://heywatch.com)
+* [Sharpcloud](https://www.sharpcloud.com)
+* [Wooga](https://www.wooga.com/games/) for the games _"Happy Hospital"_ and _"Monster World"_.
+* [Sina Weibo](https://weibo.com/)
 * [Engage](http://engage.calibreapps.com/)
-* [PoraOra](http://www.poraora.com/)
-* [Leatherbound](http://leatherbound.me/)
-* [AuthorityLabs](http://authoritylabs.com/)
-* [Fotolog](http://www.fotolog.com/)
-* [TheMatchFixer](http://www.thematchfixer.com/)
-* [Check-Host](http://check-host.net/) describes their architecture [here](http://showmetheco.de/articles/2011/1/using-perl-mojolicious-and-redis-in-a-real-world-asynchronous-application.html).
-* [ShopSquad](http://shopsquad.com/)
-* [localshow.tv](http://localshow.tv/)
-* [PennyAce](http://pennyace.com/)
-* [Nasza Klasa](http://nk.pl/)
-* [Forrst](http://forrst.com)
-* [Surfingbird](http://surfingbird.com)
-* [mig33](http://www.mig33.com)
-* [SeatGeek](http://seatgeek.com/)
-* [Wikipedia Game](http://thewikigame.com) - [Redis architecture description](http://www.clemesha.org/blog/really-using-redis-to-build-fast-real-time-web-apps/)
-* [Mogu](http://gomogu.org)
-* [Ancestry.com](http://www.ancestry.com/)
-* [SocialReviver](http://www.socialreviver.net/) by VittGam, for its Settings Cloud
-* [Telefónica Digital](http://www.telefonica.com/es/digital/html/home/)
+* [PoraOra](http://poraora.com/)
+* [Leatherbound](https://leatherbound.me/)
+* [AuthorityLabs](https://authoritylabs.com/)
+* [Fotolog](https://www.fotolog.com/)
+* [TheMatchFixer](https://www.thematchfixer.com/)
+* [Check-Host](https://check-host.net/) describes their architecture [here](http://showmetheco.de/articles/2011/1/using-perl-mojolicious-and-redis-in-a-real-world-asynchronous-application.html).
+* [ShopSquad](https://undeveloped.com/buy-domain/.com/shopsquad.com?redirected=true)
+* [localshow.tv](https://localshow.tv/)
+* [PennyAce](https://www.hugedomains.com/domain_profile.cfm?d=pennyace&e=com)
+* [Nasza Klasa](https://nk.pl/)
+* [Forrst](https://forrst.com)
+* [Surfingbird](https://surfingbird.com)
+* [mig33](https://www.mig33.com)
+* [SeatGeek](https://seatgeek.com/)
+* [Wikipedia Game](https://thewikigame.com) - [Redis architecture description](https://www.clemesha.org/blog/really-using-redis-to-build-fast-real-time-web-apps/)
+* [Mogu](https://gomogu.org)
+* [Ancestry.com](https://www.ancestry.com/)
+* [SocialReviver](https://www.socialreviver.net/) by VittGam, for its Settings Cloud
+* [Telefónica Digital](https://www.telefonica.com/es/digital/html/home/)
 * [Pond](http://web.pond.pt/)
 * [Topics.io](http://topics.io)
 * [AngiesList.com](https://github.com/angieslist/al-redis)
-* [GraphBug](http://graphbug.com/)
-* [SwarmIQ](http://www.swarmiq.com/) uses Redis as a caching / indexing layer for rapid lookups of chronological and ranked messages.
+* [GraphBug](http://www.graphbug.com/)
+* [SwarmIQ](https://www.afternic.com/forsale/swarmiq.com?utm_source=TDFS_DASLNC&utm_medium=DASLNC&utm_campaign=TDFS_DASLNC&traffic_type=TDFS_DASLNC&traffic_id=daslnc&) uses Redis as a caching / indexing layer for rapid lookups of chronological and ranked messages.
 
 This list is incomplete. If you're using Redis and would like to be
 listed, [send a pull request](https://github.com/antirez/redis-doc).


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://antirez.com/news/44 (200) with 1 occurrences could not be migrated:  
   ([https](https://antirez.com/news/44) result AnnotatedConnectException).
* [ ] http://aspell.net/ (200) with 1 occurrences could not be migrated:  
   ([https](https://aspell.net/) result AnnotatedConnectException).
* [ ] http://download.redis.io/redis-stable.tar.gz (200) with 3 occurrences could not be migrated:  
   ([https](https://download.redis.io/redis-stable.tar.gz) result AnnotatedConnectException).
* [ ] http://engage.calibreapps.com/ (200) with 1 occurrences could not be migrated:  
   ([https](https://engage.calibreapps.com/) result ConnectTimeoutException).
* [ ] http://l.yimg.com/g/images/en-us/flickr-yahoo-logo.png.v3 (200) with 1 occurrences could not be migrated:  
   ([https](https://l.yimg.com/g/images/en-us/flickr-yahoo-logo.png.v3) result 404).
* [ ] http://libhugetlbfs.sourceforge.net/ (200) with 1 occurrences could not be migrated:  
   ([https](https://libhugetlbfs.sourceforge.net/) result AnnotatedConnectException).
* [ ] http://oldhome.schmorp.de/marc/liblzf.html (200) with 1 occurrences could not be migrated:  
   ([https](https://oldhome.schmorp.de/marc/liblzf.html) result SSLHandshakeException).
* [ ] http://qix.it (200) with 1 occurrences could not be migrated:  
   ([https](https://qix.it) result AnnotatedConnectException).
* [ ] http://rediska.geometria-lab.net (200) with 2 occurrences could not be migrated:  
   ([https](https://rediska.geometria-lab.net) result SSLHandshakeException).
* [ ] http://topics.io (200) with 1 occurrences could not be migrated:  
   ([https](https://topics.io) result SSLHandshakeException).
* [ ] http://web.pond.pt/ (200) with 1 occurrences could not be migrated:  
   ([https](https://web.pond.pt/) result NotSslRecordException).
* [ ] http://www.devshed.com/c/a/BrainDump/Linux-Files-and-the-Event-Poll-Interface/ (200) with 1 occurrences could not be migrated:  
   ([https](https://www.devshed.com/c/a/BrainDump/Linux-Files-and-the-Event-Poll-Interface/) result SSLHandshakeException).
* [ ] http://www.poraora.com/ (301) with 1 occurrences could not be migrated:  
   ([https](https://www.poraora.com/) result SSLHandshakeException).
* [ ] http://graphbug.com/ (301) with 1 occurrences could not be migrated:  
   ([https](https://graphbug.com/) result AnnotatedConnectException).
* [ ] http://retwis.antirez.com (302) with 2 occurrences could not be migrated:  
   ([https](https://retwis.antirez.com) result AnnotatedConnectException).
* [ ] http://antirez.com/post/redis-memcached-benchmark.html (303) with 1 occurrences could not be migrated:  
   ([https](https://antirez.com/post/redis-memcached-benchmark.html) result AnnotatedConnectException).
* [ ] http://antirez.com/post/redis-moka-awards-2011.html (303) with 1 occurrences could not be migrated:  
   ([https](https://antirez.com/post/redis-moka-awards-2011.html) result AnnotatedConnectException).
* [ ] http://antirez.com/post/redis-persistence-demystified.html (303) with 1 occurrences could not be migrated:  
   ([https](https://antirez.com/post/redis-persistence-demystified.html) result AnnotatedConnectException).
* [ ] http://antirez.com/post/update-on-memcached-redis-benchmark.html (303) with 1 occurrences could not be migrated:  
   ([https](https://antirez.com/post/update-on-memcached-redis-benchmark.html) result AnnotatedConnectException).
* [ ] http://devblog.bu.mp/how-we-use-redis-at-bump (404) with 1 occurrences could not be migrated:  
   ([https](https://devblog.bu.mp/how-we-use-redis-at-bump) result SSLHandshakeException).
* [ ] http://showmetheco.de/articles/2011/1/using-perl-mojolicious-and-redis-in-a-real-world-asynchronous-application.html (404) with 1 occurrences could not be migrated:  
   ([https](https://showmetheco.de/articles/2011/1/using-perl-mojolicious-and-redis-in-a-real-world-asynchronous-application.html) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://www.squeaksource.com/Redis.html (302) with 1 occurrences migrated to:  
  /@cpavrZLip1SN2gzC/NeRH3bgR ([https](https://www.squeaksource.com/Redis.html) result IllegalArgumentException).
* [ ] http://shopsquad.com/ (302) with 1 occurrences migrated to:  
  https://undeveloped.com/buy-domain/.com/shopsquad.com?redirected=true ([https](https://shopsquad.com/) result SSLHandshakeException).
* [ ] http://www.swarmiq.com/ (302) with 1 occurrences migrated to:  
  https://www.afternic.com/forsale/swarmiq.com?utm_source=TDFS_DASLNC&utm_medium=DASLNC&utm_campaign=TDFS_DASLNC&traffic_type=TDFS_DASLNC&traffic_id=daslnc& ([https](https://www.swarmiq.com/) result ConnectTimeoutException).
* [ ] http://pennyace.com/ (302) with 1 occurrences migrated to:  
  https://www.hugedomains.com/domain_profile.cfm?d=pennyace&e=com ([https](https://pennyace.com/) result ConnectTimeoutException).
* [ ] http://forrst.com (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://forrst.com ([https](https://forrst.com) result ConnectTimeoutException).
* [ ] http://heywatch.com (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://heywatch.com ([https](https://heywatch.com) result ConnectTimeoutException).
* [ ] http://www.canonware.com/jemalloc/ (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://www.canonware.com/jemalloc/ ([https](https://www.canonware.com/jemalloc/) result ConnectTimeoutException).
* [ ] http://www.darkcurse.com (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://www.darkcurse.com ([https](https://www.darkcurse.com) result ConnectTimeoutException).
* [ ] http://www.mig33.com (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://www.mig33.com ([https](https://www.mig33.com) result ConnectTimeoutException).
* [ ] http://developers.diggstatic.com/sites/all/themes/about/img/footer_logo.jpg (UnknownHostException) with 1 occurrences migrated to:  
  https://developers.diggstatic.com/sites/all/themes/about/img/footer_logo.jpg ([https](https://developers.diggstatic.com/sites/all/themes/about/img/footer_logo.jpg) result UnknownHostException).
* [ ] http://gomogu.org (UnknownHostException) with 1 occurrences migrated to:  
  https://gomogu.org ([https](https://gomogu.org) result UnknownHostException).
* [ ] http://lloogg.com (UnknownHostException) with 1 occurrences migrated to:  
  https://lloogg.com ([https](https://lloogg.com) result UnknownHostException).
* [ ] http://localshow.tv/ (UnknownHostException) with 1 occurrences migrated to:  
  https://localshow.tv/ ([https](https://localshow.tv/) result UnknownHostException).
* [ ] http://redis-rb.keyvalue.org (UnknownHostException) with 1 occurrences migrated to:  
  https://redis-rb.keyvalue.org ([https](https://redis-rb.keyvalue.org) result UnknownHostException).
* [ ] http://retwisj.cloudfoundry.com/ (UnknownHostException) with 1 occurrences migrated to:  
  https://retwisj.cloudfoundry.com/ ([https](https://retwisj.cloudfoundry.com/) result UnknownHostException).
* [ ] http://retwisrb.danlucraft.com/ (UnknownHostException) with 1 occurrences migrated to:  
  https://retwisrb.danlucraft.com/ ([https](https://retwisrb.danlucraft.com/) result UnknownHostException).
* [ ] http://rubyminds.com (UnknownHostException) with 1 occurrences migrated to:  
  https://rubyminds.com ([https](https://rubyminds.com) result UnknownHostException).
* [ ] http://www.mrkris.com/ (UnknownHostException) with 1 occurrences migrated to:  
  https://www.mrkris.com/ ([https](https://www.mrkris.com/) result UnknownHostException).
* [ ] http://www.thematchfixer.com/ (UnknownHostException) with 1 occurrences migrated to:  
  https://www.thematchfixer.com/ ([https](https://www.thematchfixer.com/) result UnknownHostException).
* [ ] http://vidiowiki.com (403) with 1 occurrences migrated to:  
  https://vidiowiki.com ([https](https://vidiowiki.com) result 403).
* [ ] http://mediacdn.disqus.com/1294274648/img/disqus-logo.png (301) with 1 occurrences migrated to:  
  https://a.disquscdn.com/1294274648/img/disqus-logo.png ([https](https://mediacdn.disqus.com/1294274648/img/disqus-logo.png) result 404).
* [ ] http://bretthoerner.com/2011/2/21/redis-at-disqus/ (404) with 1 occurrences migrated to:  
  https://bretthoerner.com/2011/2/21/redis-at-disqus/ ([https](https://bretthoerner.com/2011/2/21/redis-at-disqus/) result 404).
* [ ] http://qi4j.org/extension-es-redis.html (301) with 1 occurrences migrated to:  
  https://polygene.apache.org/extension-es-redis.html ([https](https://qi4j.org/extension-es-redis.html) result 404).
* [ ] http://sstatic.net/stackoverflow/img/logo.png (404) with 1 occurrences migrated to:  
  https://sstatic.net/stackoverflow/img/logo.png ([https](https://sstatic.net/stackoverflow/img/logo.png) result 404).
* [ ] http://www.engineyard.com/images/logo.png (301) with 1 occurrences migrated to:  
  https://www.engineyard.com/images/logo.png ([https](https://www.engineyard.com/images/logo.png) result 404).
* [ ] http://www.redhat.com/magazine/001nov04/features/vm/ (302) with 1 occurrences migrated to:  
  https://www.redhat.com/magazine/001nov04/features/vm/ ([https](https://www.redhat.com/magazine/001nov04/features/vm/) result 404).
* [ ] http://www.telefonica.com/es/digital/html/home/ (301) with 1 occurrences migrated to:  
  https://www.telefonica.com/es/digital/html/home/ ([https](https://www.telefonica.com/es/digital/html/home/) result 404).
* [ ] http://www.socialreviver.net/ (301) with 1 occurrences migrated to:  
  https://www.socialreviver.net/ ([https](https://www.socialreviver.net/) result 503).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://authoritylabs.com/ with 1 occurrences migrated to:  
  https://authoritylabs.com/ ([https](https://authoritylabs.com/) result 200).
* [ ] http://bitbucket.org/videlalvaro/redis-haskell/src with 1 occurrences migrated to:  
  https://bitbucket.org/videlalvaro/redis-haskell/src ([https](https://bitbucket.org/videlalvaro/redis-haskell/src) result 200).
* [ ] http://bitbucket.org/videlalvaro/redis-haskell/wiki/Home with 1 occurrences migrated to:  
  https://bitbucket.org/videlalvaro/redis-haskell/wiki/Home ([https](https://bitbucket.org/videlalvaro/redis-haskell/wiki/Home) result 200).
* [ ] http://bradjasper.com/ with 1 occurrences migrated to:  
  https://bradjasper.com/ ([https](https://bradjasper.com/) result 200).
* [ ] http://check-host.net/ with 1 occurrences migrated to:  
  https://check-host.net/ ([https](https://check-host.net/) result 200).
* [ ] http://dormando.livejournal.com/525147.html with 1 occurrences migrated to:  
  https://dormando.livejournal.com/525147.html ([https](https://dormando.livejournal.com/525147.html) result 200).
* [ ] http://en.wikipedia.org/wiki/Comparison_of_file_systems with 1 occurrences migrated to:  
  https://en.wikipedia.org/wiki/Comparison_of_file_systems ([https](https://en.wikipedia.org/wiki/Comparison_of_file_systems) result 200).
* [ ] http://en.wikipedia.org/wiki/Publish/subscribe with 1 occurrences migrated to:  
  https://en.wikipedia.org/wiki/Publish/subscribe ([https](https://en.wikipedia.org/wiki/Publish/subscribe) result 200).
* [ ] http://en.wikipedia.org/wiki/Unix_time with 1 occurrences migrated to:  
  https://en.wikipedia.org/wiki/Unix_time ([https](https://en.wikipedia.org/wiki/Unix_time) result 200).
* [ ] http://favstar.fm with 1 occurrences migrated to:  
  https://favstar.fm ([https](https://favstar.fm) result 200).
* [ ] http://github.com/Shumkov/Rediska with 1 occurrences migrated to:  
  https://github.com/Shumkov/Rediska ([https](https://github.com/Shumkov/Rediska) result 200).
* [ ] http://github.com/antirez/redis with 1 occurrences migrated to:  
  https://github.com/antirez/redis ([https](https://github.com/antirez/redis) result 200).
* [ ] http://github.com/antirez/redis-tools with 1 occurrences migrated to:  
  https://github.com/antirez/redis-tools ([https](https://github.com/antirez/redis-tools) result 200).
* [ ] http://github.com/antirez/redis/issues/141 with 1 occurrences migrated to:  
  https://github.com/antirez/redis/issues/141 ([https](https://github.com/antirez/redis/issues/141) result 200).
* [ ] http://github.com/antirez/redis/issues/267 with 1 occurrences migrated to:  
  https://github.com/antirez/redis/issues/267 ([https](https://github.com/antirez/redis/issues/267) result 200).
* [ ] http://github.com/antirez/redis/issues/460 with 1 occurrences migrated to:  
  https://github.com/antirez/redis/issues/460 ([https](https://github.com/antirez/redis/issues/460) result 200).
* [ ] http://github.com/antirez/redis/raw/2.2/redis.conf with 2 occurrences migrated to:  
  https://github.com/antirez/redis/raw/2.2/redis.conf ([https](https://github.com/antirez/redis/raw/2.2/redis.conf) result 200).
* [ ] http://github.com/chriso/redback with 1 occurrences migrated to:  
  https://github.com/chriso/redback ([https](https://github.com/chriso/redback) result 200).
* [ ] http://github.com/ezmobius/redis-rb with 1 occurrences migrated to:  
  https://github.com/ezmobius/redis-rb ([https](https://github.com/ezmobius/redis-rb) result 200).
* [ ] http://github.com/qi4j/qi4j-sdk with 1 occurrences migrated to:  
  https://github.com/qi4j/qi4j-sdk ([https](https://github.com/qi4j/qi4j-sdk) result 200).
* [ ] http://hackage.haskell.org/package/hedis with 1 occurrences migrated to:  
  https://hackage.haskell.org/package/hedis ([https](https://hackage.haskell.org/package/hedis) result 200).
* [ ] http://iwantmyname.com with 1 occurrences migrated to:  
  https://iwantmyname.com ([https](https://iwantmyname.com) result 200).
* [ ] http://leatherbound.me/ with 1 occurrences migrated to:  
  https://leatherbound.me/ ([https](https://leatherbound.me/) result 200).
* [ ] http://linux.die.net/man/2/fork with 2 occurrences migrated to:  
  https://linux.die.net/man/2/fork ([https](https://linux.die.net/man/2/fork) result 200).
* [ ] http://linux.die.net/man/2/fsync with 1 occurrences migrated to:  
  https://linux.die.net/man/2/fsync ([https](https://linux.die.net/man/2/fsync) result 200).
* [ ] http://lwn.net/Articles/374424/ with 1 occurrences migrated to:  
  https://lwn.net/Articles/374424/ ([https](https://lwn.net/Articles/374424/) result 200).
* [ ] http://man.cx/accept with 1 occurrences migrated to:  
  https://man.cx/accept ([https](https://man.cx/accept) result 200).
* [ ] http://man.cx/accept%282%29 with 1 occurrences migrated to:  
  https://man.cx/accept%282%29 ([https](https://man.cx/accept%282%29) result 200).
* [ ] http://man.cx/epoll_create%282%29 with 1 occurrences migrated to:  
  https://man.cx/epoll_create%282%29 ([https](https://man.cx/epoll_create%282%29) result 200).
* [ ] http://man.cx/epoll_ctl with 1 occurrences migrated to:  
  https://man.cx/epoll_ctl ([https](https://man.cx/epoll_ctl) result 200).
* [ ] http://man.cx/epoll_wait with 1 occurrences migrated to:  
  https://man.cx/epoll_wait ([https](https://man.cx/epoll_wait) result 200).
* [ ] http://oknotizie.virgilio.it (301) with 1 occurrences migrated to:  
  https://notizie.virgilio.it ([https](https://oknotizie.virgilio.it) result 200).
* [ ] http://ohm.keyvalue.org with 1 occurrences migrated to:  
  https://ohm.keyvalue.org ([https](https://ohm.keyvalue.org) result 200).
* [ ] http://redis.io with 1 occurrences migrated to:  
  https://redis.io ([https](https://redis.io) result 200).
* [ ] http://redis.io/clients with 2 occurrences migrated to:  
  https://redis.io/clients ([https](https://redis.io/clients) result 200).
* [ ] http://redis.io/commands/client-list with 2 occurrences migrated to:  
  https://redis.io/commands/client-list ([https](https://redis.io/commands/client-list) result 200).
* [ ] http://redis.io/commands/script-load with 1 occurrences migrated to:  
  https://redis.io/commands/script-load ([https](https://redis.io/commands/script-load) result 200).
* [ ] http://redis.io/topics/data-types-intro with 1 occurrences migrated to:  
  https://redis.io/topics/data-types-intro ([https](https://redis.io/topics/data-types-intro) result 200).
* [ ] http://redis.io/topics/persistence with 2 occurrences migrated to:  
  https://redis.io/topics/persistence ([https](https://redis.io/topics/persistence) result 200).
* [ ] http://seatgeek.com/ with 1 occurrences migrated to:  
  https://seatgeek.com/ ([https](https://seatgeek.com/) result 200).
* [ ] http://static.guim.co.uk/static/97665/networkfront/images/guardian_logo.png with 1 occurrences migrated to:  
  https://static.guim.co.uk/static/97665/networkfront/images/guardian_logo.png ([https](https://static.guim.co.uk/static/97665/networkfront/images/guardian_logo.png) result 200).
* [ ] http://static.mlstatic.com/org-img/logo_ml/logoAlpha.png with 1 occurrences migrated to:  
  https://static.mlstatic.com/org-img/logo_ml/logoAlpha.png ([https](https://static.mlstatic.com/org-img/logo_ml/logoAlpha.png) result 200).
* [ ] http://static.pe.studivz.net/20101222-0/Img/logo.png with 1 occurrences migrated to:  
  https://static.pe.studivz.net/20101222-0/Img/logo.png ([https](https://static.pe.studivz.net/20101222-0/Img/logo.png) result 200).
* [ ] http://surfingbird.com with 1 occurrences migrated to:  
  https://surfingbird.com ([https](https://surfingbird.com) result 200).
* [ ] http://twitter.com/antirez with 1 occurrences migrated to:  
  https://twitter.com/antirez ([https](https://twitter.com/antirez) result 200).
* [ ] http://twitter.com/costinl with 1 occurrences migrated to:  
  https://twitter.com/costinl ([https](https://twitter.com/costinl) result 200).
* [ ] http://twitter.com/pnoordhuis with 1 occurrences migrated to:  
  https://twitter.com/pnoordhuis ([https](https://twitter.com/pnoordhuis) result 200).
* [ ] http://webd.is/ with 1 occurrences migrated to:  
  https://webd.is/ ([https](https://webd.is/) result 200).
* [ ] http://wiki.call-cc.org/eggref/4/redis-client with 1 occurrences migrated to:  
  https://wiki.call-cc.org/eggref/4/redis-client ([https](https://wiki.call-cc.org/eggref/4/redis-client) result 200).
* [ ] http://www.ancestry.com/ with 1 occurrences migrated to:  
  https://www.ancestry.com/ ([https](https://www.ancestry.com/) result 200).
* [ ] http://www.boxcar.io with 1 occurrences migrated to:  
  https://www.boxcar.io ([https](https://www.boxcar.io) result 200).
* [ ] http://www.cliki.net/cl-redis with 1 occurrences migrated to:  
  https://www.cliki.net/cl-redis ([https](https://www.cliki.net/cl-redis) result 200).
* [ ] http://www.linuxjournal.com/article/6340 with 1 occurrences migrated to:  
  https://www.linuxjournal.com/article/6340 ([https](https://www.linuxjournal.com/article/6340) result 200).
* [ ] http://www.lua.org/pil/19.1.html with 1 occurrences migrated to:  
  https://www.lua.org/pil/19.1.html ([https](https://www.lua.org/pil/19.1.html) result 200).
* [ ] http://www.rsyslog.com/doc/build_from_repo.html with 1 occurrences migrated to:  
  https://www.rsyslog.com/doc/build_from_repo.html ([https](https://www.rsyslog.com/doc/build_from_repo.html) result 200).
* [ ] http://www.sharpcloud.com with 1 occurrences migrated to:  
  https://www.sharpcloud.com ([https](https://www.sharpcloud.com) result 200).
* [ ] http://www.wooga.com/games/ with 1 occurrences migrated to:  
  https://www.wooga.com/games/ ([https](https://www.wooga.com/games/) result 200).
* [ ] http://adilbaig.github.com/Tiny-Redis/ with 1 occurrences migrated to:  
  https://adilbaig.github.com/Tiny-Redis/ ([https](https://adilbaig.github.com/Tiny-Redis/) result 301).
* [ ] http://blog.getspool.com/2011/11/29/fast-easy-realtime-metrics-using-redis-bitmaps with 2 occurrences migrated to:  
  https://blog.getspool.com/2011/11/29/fast-easy-realtime-metrics-using-redis-bitmaps ([https](https://blog.getspool.com/2011/11/29/fast-easy-realtime-metrics-using-redis-bitmaps) result 301).
* [ ] http://carlhoerberg.github.com/meerkat/ with 1 occurrences migrated to:  
  https://carlhoerberg.github.com/meerkat/ ([https](https://carlhoerberg.github.com/meerkat/) result 301).
* [ ] http://citrusbyte.com with 1 occurrences migrated to:  
  https://citrusbyte.com ([https](https://citrusbyte.com) result 301).
* [ ] http://code.flickr.com/blog/2011/10/11/talk-real-time-updates-on-the-cheap-for-fun-and-profit/ (301) with 1 occurrences migrated to:  
  https://code.flickr.net/blog/2011/10/11/talk-real-time-updates-on-the-cheap-for-fun-and-profit/ ([https](https://code.flickr.com/blog/2011/10/11/talk-real-time-updates-on-the-cheap-for-fun-and-profit/) result 301).
* [ ] http://code.google.com/p/booksleeve/ with 1 occurrences migrated to:  
  https://code.google.com/p/booksleeve/ ([https](https://code.google.com/p/booksleeve/) result 301).
* [ ] http://code.google.com/p/credis/source/browse with 1 occurrences migrated to:  
  https://code.google.com/p/credis/source/browse ([https](https://code.google.com/p/credis/source/browse) result 301).
* [ ] http://code.google.com/p/eredis with 1 occurrences migrated to:  
  https://code.google.com/p/eredis ([https](https://code.google.com/p/eredis) result 301).
* [ ] http://code.google.com/p/google-perftools/ with 1 occurrences migrated to:  
  https://code.google.com/p/google-perftools/ ([https](https://code.google.com/p/google-perftools/) result 301).
* [ ] http://code.google.com/p/hxneko-redis with 1 occurrences migrated to:  
  https://code.google.com/p/hxneko-redis ([https](https://code.google.com/p/hxneko-redis) result 301).
* [ ] http://code.google.com/p/hxneko-redis/source/browse with 1 occurrences migrated to:  
  https://code.google.com/p/hxneko-redis/source/browse ([https](https://code.google.com/p/hxneko-redis/source/browse) result 301).
* [ ] http://code.google.com/p/jdbc-redis with 1 occurrences migrated to:  
  https://code.google.com/p/jdbc-redis ([https](https://code.google.com/p/jdbc-redis) result 301).
* [ ] http://code.google.com/p/jdbc-redis/source/browse with 1 occurrences migrated to:  
  https://code.google.com/p/jdbc-redis/source/browse ([https](https://code.google.com/p/jdbc-redis/source/browse) result 301).
* [ ] http://code.google.com/p/jredis with 1 occurrences migrated to:  
  https://code.google.com/p/jredis ([https](https://code.google.com/p/jredis) result 301).
* [ ] http://code.google.com/p/redis with 1 occurrences migrated to:  
  https://code.google.com/p/redis ([https](https://code.google.com/p/redis) result 301).
* [ ] http://code.google.com/p/redis/downloads/list with 2 occurrences migrated to:  
  https://code.google.com/p/redis/downloads/list ([https](https://code.google.com/p/redis/downloads/list) result 301).
* [ ] http://code.google.com/p/redis/issues/detail?id=270 with 1 occurrences migrated to:  
  https://code.google.com/p/redis/issues/detail?id=270 ([https](https://code.google.com/p/redis/issues/detail?id=270) result 301).
* [ ] http://code.google.com/p/redis/issues/detail?id=34 with 1 occurrences migrated to:  
  https://code.google.com/p/redis/issues/detail?id=34 ([https](https://code.google.com/p/redis/issues/detail?id=34) result 301).
* [ ] http://code.google.com/p/redis/wiki/README with 1 occurrences migrated to:  
  https://code.google.com/p/redis/wiki/README ([https](https://code.google.com/p/redis/wiki/README) result 301).
* [ ] http://code.google.com/p/tcgl/ with 1 occurrences migrated to:  
  https://code.google.com/p/tcgl/ ([https](https://code.google.com/p/tcgl/) result 301).
* [ ] http://engineyard.com with 1 occurrences migrated to:  
  https://engineyard.com ([https](https://engineyard.com) result 301).
* [ ] http://github.com/SpringSource/spring-data-redis with 1 occurrences migrated to:  
  https://github.com/SpringSource/spring-data-redis ([https](https://github.com/SpringSource/spring-data-redis) result 301).
* [ ] http://groups.google.com/group/redis-db with 1 occurrences migrated to:  
  https://groups.google.com/group/redis-db ([https](https://groups.google.com/group/redis-db) result 301).
* [ ] http://groups.google.com/group/redis-db/browse_thread/thread/b52814e9ef15b8d0/ with 1 occurrences migrated to:  
  https://groups.google.com/group/redis-db/browse_thread/thread/b52814e9ef15b8d0/ ([https](https://groups.google.com/group/redis-db/browse_thread/thread/b52814e9ef15b8d0/) result 301).
* [ ] http://j.mp/eo6z6I with 1 occurrences migrated to:  
  https://j.mp/eo6z6I ([https](https://j.mp/eo6z6I) result 301).
* [ ] http://linode.com with 1 occurrences migrated to:  
  https://linode.com ([https](https://linode.com) result 301).
* [ ] http://memtest86.com with 1 occurrences migrated to:  
  https://memtest86.com ([https](https://memtest86.com) result 301).
* [ ] http://meta.stackoverflow.com/questions/69164/does-stackoverflow-use-caching-and-if-so-how/69172 with 1 occurrences migrated to:  
  https://meta.stackoverflow.com/questions/69164/does-stackoverflow-use-caching-and-if-so-how/69172 ([https](https://meta.stackoverflow.com/questions/69164/does-stackoverflow-use-caching-and-if-so-how/69172) result 301).
* [ ] http://mperham.github.com/sidekiq/ with 1 occurrences migrated to:  
  https://mperham.github.com/sidekiq/ ([https](https://mperham.github.com/sidekiq/) result 301).
* [ ] http://nuget.org/List/Packages/Sider with 1 occurrences migrated to:  
  https://nuget.org/List/Packages/Sider ([https](https://nuget.org/List/Packages/Sider) result 301).
* [ ] http://pypi.python.org/pypi/txredis/0.1.1 with 1 occurrences migrated to:  
  https://pypi.python.org/pypi/txredis/0.1.1 ([https](https://pypi.python.org/pypi/txredis/0.1.1) result 301).
* [ ] http://redis.codeplex.com/ with 1 occurrences migrated to:  
  https://redis.codeplex.com/ ([https](https://redis.codeplex.com/) result 301).
* [ ] http://search.cpan.org/dist/AnyEvent-Hiredis with 1 occurrences migrated to:  
  https://search.cpan.org/dist/AnyEvent-Hiredis ([https](https://search.cpan.org/dist/AnyEvent-Hiredis) result 301).
* [ ] http://search.cpan.org/dist/AnyEvent-Redis with 1 occurrences migrated to:  
  https://search.cpan.org/dist/AnyEvent-Redis ([https](https://search.cpan.org/dist/AnyEvent-Redis) result 301).
* [ ] http://search.cpan.org/dist/AnyEvent-Redis-RipeRedis with 1 occurrences migrated to:  
  https://search.cpan.org/dist/AnyEvent-Redis-RipeRedis ([https](https://search.cpan.org/dist/AnyEvent-Redis-RipeRedis) result 301).
* [ ] http://search.cpan.org/dist/Danga-Socket-Redis with 1 occurrences migrated to:  
  https://search.cpan.org/dist/Danga-Socket-Redis ([https](https://search.cpan.org/dist/Danga-Socket-Redis) result 301).
* [ ] http://search.cpan.org/dist/MojoX-Redis with 1 occurrences migrated to:  
  https://search.cpan.org/dist/MojoX-Redis ([https](https://search.cpan.org/dist/MojoX-Redis) result 301).
* [ ] http://search.cpan.org/dist/Redis with 1 occurrences migrated to:  
  https://search.cpan.org/dist/Redis ([https](https://search.cpan.org/dist/Redis) result 301).
* [ ] http://search.cpan.org/dist/Redis-hiredis/ with 1 occurrences migrated to:  
  https://search.cpan.org/dist/Redis-hiredis/ ([https](https://search.cpan.org/dist/Redis-hiredis/) result 301).
* [ ] http://search.cpan.org/dist/RedisDB with 1 occurrences migrated to:  
  https://search.cpan.org/dist/RedisDB ([https](https://search.cpan.org/dist/RedisDB) result 301).
* [ ] http://simonwillison.net/2009/Dec/20/crowdsourcing with 1 occurrences migrated to:  
  https://simonwillison.net/2009/Dec/20/crowdsourcing ([https](https://simonwillison.net/2009/Dec/20/crowdsourcing) result 301).
* [ ] http://thewikigame.com with 1 occurrences migrated to:  
  https://thewikigame.com ([https](https://thewikigame.com) result 301).
* [ ] http://top10.com with 1 occurrences migrated to:  
  https://top10.com ([https](https://top10.com) result 301).
* [ ] http://vmware.com with 2 occurrences migrated to:  
  https://vmware.com ([https](https://vmware.com) result 301).
* [ ] http://t.sina.com.cn/ (301) with 1 occurrences migrated to:  
  https://weibo.com/ ([https](https://t.sina.com.cn/) result 301).
* [ ] http://wish.hu with 1 occurrences migrated to:  
  https://wish.hu ([https](https://wish.hu) result 301).
* [ ] http://www.clemesha.org/blog/really-using-redis-to-build-fast-real-time-web-apps/ with 1 occurrences migrated to:  
  https://www.clemesha.org/blog/really-using-redis-to-build-fast-real-time-web-apps/ ([https](https://www.clemesha.org/blog/really-using-redis-to-build-fast-real-time-web-apps/) result 301).
* [ ] http://www.hitmeister.de/ with 1 occurrences migrated to:  
  https://www.hitmeister.de/ ([https](https://www.hitmeister.de/) result 301).
* [ ] http://slicehost.com (301) with 1 occurrences migrated to:  
  https://www.rackspace.com/cloud/vps/ ([https](https://slicehost.com) result 301).
* [ ] http://www.springsource.org/spring-data/redis with 1 occurrences migrated to:  
  https://www.springsource.org/spring-data/redis ([https](https://www.springsource.org/spring-data/redis) result 301).
* [ ] http://www.tweetdeck.com/assets/logo/UpdatedLogo-500x500.png with 1 occurrences migrated to:  
  https://www.tweetdeck.com/assets/logo/UpdatedLogo-500x500.png ([https](https://www.tweetdeck.com/assets/logo/UpdatedLogo-500x500.png) result 301).
* [ ] http://www.zoombu.co.uk with 1 occurrences migrated to:  
  https://www.zoombu.co.uk ([https](https://www.zoombu.co.uk) result 301).
* [ ] http://blog.superfeedr.com/redis/mysql/memcache/datastore/performance/redis-at-superfeedr with 1 occurrences migrated to:  
  https://blog.superfeedr.com/redis/mysql/memcache/datastore/performance/redis-at-superfeedr ([https](https://blog.superfeedr.com/redis/mysql/memcache/datastore/performance/redis-at-superfeedr) result 302).
* [ ] http://nk.pl/ with 1 occurrences migrated to:  
  https://nk.pl/ ([https](https://nk.pl/) result 302).
* [ ] http://us.blizzard.com/_images/company/about/awards/logo-dev.gif with 1 occurrences migrated to:  
  https://us.blizzard.com/_images/company/about/awards/logo-dev.gif ([https](https://us.blizzard.com/_images/company/about/awards/logo-dev.gif) result 302).
* [ ] http://www.fotolog.com/ with 1 occurrences migrated to:  
  https://www.fotolog.com/ ([https](https://www.fotolog.com/) result 302).
* [ ] http://www.moodstocks.com/2010/11/26/the-tech-behind-moodstocks-notes with 1 occurrences migrated to:  
  https://www.moodstocks.com/2010/11/26/the-tech-behind-moodstocks-notes ([https](https://www.moodstocks.com/2010/11/26/the-tech-behind-moodstocks-notes) result 302).